### PR TITLE
Stabilize performance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "MTR",
-    // "initializeCommand": ".devcontainer/initialize-command.sh dever", // Bakes to tag mtc:devcontainer
+    "initializeCommand": ".devcontainer/initialize-command.sh dever", // Bakes to tag mtc:devcontainer
     "image": "mtc:devcontainer",
     "runArgs": [
         // ################################################################################

--- a/.devcontainer/robot/README.md
+++ b/.devcontainer/robot/README.md
@@ -1,0 +1,32 @@
+# Robot setup
+
+There are a few initial steps to set up the robot environment for hardware setup.
+
+## Udev rules
+
+To allow access to the robot hardware, you need to set up udev rules. These rules define how devices are accessed and managed by the system.
+
+```shell
+sudo cp .devcontainer/robot/data/etc/udev/rules.d/* /etc/udev/rules.d/
+```
+
+To apply the new rules without rebooting:
+
+```shell
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+## Kernel module parameters
+
+To set kernel module parameters, you need to create a configuration file in `/etc/modprobe.d/` to apply the changes during the boot process.
+
+```shell
+sudo cp .devcontainer/robot/data/etc/modprobe.d/* /etc/modprobe.d/
+```
+
+To emulate the new parameters without rebooting:
+
+```shell
+sudo sh -c 'echo 1024 > /sys/module/usbcore/parameters/usbfs_memory_mb'
+```

--- a/.devcontainer/robot/data/etc/modprobe.d/usbcore.conf
+++ b/.devcontainer/robot/data/etc/modprobe.d/usbcore.conf
@@ -1,0 +1,1 @@
+options usbcore usbfs_memory_mb=1024

--- a/.devcontainer/robot/data/etc/udev/rules.d/50-usb-microntracker.rules
+++ b/.devcontainer/robot/data/etc/udev/rules.d/50-usb-microntracker.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2978", ATTRS{idProduct}=="a011", MODE="0664", GROUP="video"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,10 +24,13 @@
         "devcontainers",
         "dever",
         "eamodio",
+        "microntracker",
         "PTRACE",
+        "rclcpp",
         "rviz",
         "seccomp",
-        "vitaliymaz"
+        "vitaliymaz",
+        "Xform"
     ],
     "cmake.configureOnOpen": false,
     "git.detectSubmodulesLimit": 50,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,45 @@
+{
+    "C_Cpp.default.cStandard": "c11",
+    "C_Cpp.default.compilerPath": "/usr/bin/g++",
+    "C_Cpp.default.cppStandard": "c++17",
+    "C_Cpp.default.defines": [
+        "ROS_FOUND"
+    ],
+    "C_Cpp.default.includePath": [
+        // "${workspaceFolder}/**",
+        "/opt/mtr_ws/src/**/include/**",
+        "/opt/mtr_ws/install/**/include/**",
+        "/opt/ros/jazzy/include/**",
+        "/usr/include/**",
+    ],
+    "C_Cpp.default.intelliSenseMode": "linux-gcc-x64",
+    "C_Cpp.intelliSenseEngine": "default",
+    "cSpell.enabled": true,
+    "cSpell.language": "en",
+    "cSpell.words": [
+        "azuretools",
+        "ccache",
+        "colcon",
+        "devcontainer",
+        "devcontainers",
+        "dever",
+        "eamodio",
+        "PTRACE",
+        "rviz",
+        "seccomp",
+        "vitaliymaz"
+    ],
+    "cmake.configureOnOpen": false,
+    "git.detectSubmodulesLimit": 50,
+    "python.analysis.extraPaths": [
+        "/opt/ros/jazzy/lib/python3.12/site-packages"
+    ],
+    "python.autoComplete.extraPaths": [
+        "/opt/ros/jazzy/lib/python3.12/site-packages"
+    ],
+    "terminal.integrated.commandsToSkipShell": [
+        "-workbench.action.terminal.findNext",
+        "-search.action.focusNextSearchResult",
+        "-workbench.action.debug.start"
+    ]
+}

--- a/microntracker_components/CMakeLists.txt
+++ b/microntracker_components/CMakeLists.txt
@@ -7,12 +7,18 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(generate_parameter_library REQUIRED)
 find_package(microntracker REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
+
+generate_parameter_library(
+  microntracker_components_parameters
+  src/microntracker_components_parameters.yaml
+)
 
 add_library(microntracker_component SHARED src/microntracker_component.cpp)
 target_include_directories(microntracker_component PUBLIC
@@ -28,6 +34,7 @@ ament_target_dependencies(microntracker_component
   visualization_msgs
 )
 target_link_libraries(microntracker_component
+  microntracker_components_parameters
   ${microntracker_LIBRARIES}
 )
 
@@ -38,7 +45,7 @@ rclcpp_components_register_node(
 )
 
 ament_export_targets(export_microntracker_component)
-install(TARGETS microntracker_component
+install(TARGETS microntracker_component microntracker_components_parameters
         EXPORT export_microntracker_component
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib

--- a/microntracker_components/include/microntracker_components/microntracker_component.hpp
+++ b/microntracker_components/include/microntracker_components/microntracker_component.hpp
@@ -11,8 +11,8 @@
 #include "microntracker_components/mtc_wrapper.hpp"
 #include "microntracker_components/visibility_control.h"
 #include "rclcpp/rclcpp.hpp"
-#include "visualization_msgs/msg/marker_array.hpp"
 #include "sensor_msgs/msg/image.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 namespace microntracker_components
 {

--- a/microntracker_components/include/microntracker_components/microntracker_component.hpp
+++ b/microntracker_components/include/microntracker_components/microntracker_component.hpp
@@ -36,6 +36,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_image_pub_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_image_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_array_pub_;
+  rclcpp::Time mt_epoch;
   size_t count_;
 };
 

--- a/microntracker_components/include/microntracker_components/microntracker_component.hpp
+++ b/microntracker_components/include/microntracker_components/microntracker_component.hpp
@@ -3,9 +3,11 @@
 #ifndef MICRONTRACKER_COMPONENTS__MICRONTRACKER_COMPONENT_HPP_
 #define MICRONTRACKER_COMPONENTS__MICRONTRACKER_COMPONENT_HPP_
 
-#include <string>
+#include <memory>
 #include <optional>
+#include <string>
 
+#include "microntracker_components/microntracker_components_parameters.hpp"
 #include "microntracker_components/mtc_wrapper.hpp"
 #include "microntracker_components/visibility_control.h"
 #include "rclcpp/rclcpp.hpp"
@@ -33,11 +35,13 @@ private:
   mtc::mtHandle IdentifiedMarkers;
   mtc::mtHandle IdentifyingCamera;
   mtc::mtHandle PoseXf;
+  Params params_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_image_pub_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_image_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_array_pub_;
   rclcpp::Time mt_epoch;
   size_t count_;
+  std::shared_ptr<ParamListener> param_listener_;
 };
 
 std::optional<std::string> getMTHome();

--- a/microntracker_components/include/microntracker_components/microntracker_component.hpp
+++ b/microntracker_components/include/microntracker_components/microntracker_component.hpp
@@ -44,8 +44,6 @@ private:
   std::shared_ptr<ParamListener> param_listener_;
 };
 
-std::optional<std::string> getMTHome();
-
 }  // namespace microntracker_components
 
 #endif  // MICRONTRACKER_COMPONENTS__MICRONTRACKER_COMPONENT_HPP_

--- a/microntracker_components/include/microntracker_components/microntracker_component.hpp
+++ b/microntracker_components/include/microntracker_components/microntracker_component.hpp
@@ -24,7 +24,6 @@ public:
 
 protected:
   void init_mtc();
-  void on_timer();
   void process_frames();
 
 private:
@@ -37,7 +36,6 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_image_pub_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_image_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_array_pub_;
-  rclcpp::TimerBase::SharedPtr timer_;
   size_t count_;
 };
 

--- a/microntracker_components/include/microntracker_components/mtc_wrapper.hpp
+++ b/microntracker_components/include/microntracker_components/mtc_wrapper.hpp
@@ -4,10 +4,40 @@
 #define MICRONTRACKER_COMPONENTS__MTC_WRAPPER_HPP_
 
 #include <cinttypes>  // Include standard library headers
+#include <string>
 
 namespace mtc
 {
   #include "microntracker/MTC.h"
+}  // namespace mtc
+
+namespace mtr
+{
+mtc::mtFrameType stringToFrameType(const std::string & frameType)
+{
+  if (frameType == "None") {return mtc::mtFrameType::None;}
+  if (frameType == "Full") {return mtc::mtFrameType::Full;}
+  if (frameType == "ROIs") {return mtc::mtFrameType::ROIs;}
+  if (frameType == "Alternating") {return mtc::mtFrameType::Alternating;}
+  throw std::invalid_argument("Invalid frame type");
 }
+
+mtc::mtDecimation stringToDecimation(const std::string & decimation)
+{
+  if (decimation == "None") {return mtc::mtDecimation::None;}
+  if (decimation == "Dec11") {return mtc::mtDecimation::Dec11;}
+  if (decimation == "Dec21") {return mtc::mtDecimation::Dec21;}
+  if (decimation == "Dec41") {return mtc::mtDecimation::Dec41;}
+  throw std::invalid_argument("Invalid decimation");
+}
+
+mtc::mtBitDepth stringToBitDepth(const std::string & bitDepth)
+{
+  if (bitDepth == "None") {return mtc::mtBitDepth::None;}
+  if (bitDepth == "Bpp14") {return mtc::mtBitDepth::Bpp14;}
+  if (bitDepth == "Bpp12") {return mtc::mtBitDepth::Bpp12;}
+  throw std::invalid_argument("Invalid bit depth");
+}
+}  // namespace mtr
 
 #endif  // MICRONTRACKER_COMPONENTS__MTC_WRAPPER_HPP_

--- a/microntracker_components/include/microntracker_components/mtc_wrapper.hpp
+++ b/microntracker_components/include/microntracker_components/mtc_wrapper.hpp
@@ -13,6 +13,10 @@ namespace mtc
 
 namespace mtr
 {
+
+#define MTR(func) {int r = func; \
+  if (r != mtc::mtOK) RCLCPP_ERROR(this->get_logger(), "MTC error: %s", mtc::MTLastErrorString());}
+
 mtc::mtFrameType stringToFrameType(const std::string & frameType)
 {
   if (frameType == "None") {return mtc::mtFrameType::None;}

--- a/microntracker_components/include/microntracker_components/mtc_wrapper.hpp
+++ b/microntracker_components/include/microntracker_components/mtc_wrapper.hpp
@@ -38,6 +38,14 @@ mtc::mtBitDepth stringToBitDepth(const std::string & bitDepth)
   if (bitDepth == "Bpp12") {return mtc::mtBitDepth::Bpp12;}
   throw std::invalid_argument("Invalid bit depth");
 }
+
+std::optional<std::string> getMTHome()
+{
+  if (const char * localNamePtr = getenv("MTHome")) {
+    return std::string(localNamePtr);
+  }
+  return std::nullopt;
+}
 }  // namespace mtr
 
 #endif  // MICRONTRACKER_COMPONENTS__MTC_WRAPPER_HPP_

--- a/microntracker_components/package.xml
+++ b/microntracker_components/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>generate_parameter_library</depend>
   <depend>microntracker</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp</depend>

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -29,6 +29,9 @@ MicronTrackerDriver::MicronTrackerDriver(const rclcpp::NodeOptions & options)
   left_image_pub_ = create_publisher<sensor_msgs::msg::Image>("left_image", 10);
   right_image_pub_ = create_publisher<sensor_msgs::msg::Image>("right_image", 10);
 
+  param_listener_ = std::make_shared<ParamListener>(get_node_parameters_interface());
+  params_ = param_listener_->get_params();
+
   // Initialize MTC library and connect to cameras
   init_mtc();
 
@@ -70,9 +73,9 @@ void MicronTrackerDriver::init_mtc()
               CurrCameraSerialNum);
 
   mtc::mtStreamingModeStruct mode{
-    mtc::mtFrameType::Alternating,
-    mtc::mtDecimation::Dec41,
-    mtc::mtBitDepth::Bpp12};
+    mtr::stringToFrameType(params_.mt.frame_type),
+    mtr::stringToDecimation(params_.mt.decimation),
+    mtr::stringToBitDepth(params_.mt.bit_depth)};
 
   MTC(mtc::Cameras_StreamingModeSet(mode, CurrCameraSerialNum));
 

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -129,7 +129,7 @@ void MicronTrackerDriver::process_frames()
 
   // Publish left image
   auto left_image_msg = std::make_unique<sensor_msgs::msg::Image>();
-  left_image_msg->header.frame_id = "camera";
+  left_image_msg->header.frame_id = params_.frame_id;
   left_image_msg->header.stamp = frame_stamp;
   left_image_msg->height = y;
   left_image_msg->width = x;
@@ -141,7 +141,7 @@ void MicronTrackerDriver::process_frames()
 
   // Publish right image
   auto right_image_msg = std::make_unique<sensor_msgs::msg::Image>();
-  right_image_msg->header.frame_id = "camera";
+  right_image_msg->header.frame_id = params_.frame_id;
   right_image_msg->header.stamp = frame_stamp;
   right_image_msg->height = y;
   right_image_msg->width = x;
@@ -174,7 +174,7 @@ void MicronTrackerDriver::process_frames()
       visualization_msgs::msg::Marker marker;
       marker.type = visualization_msgs::msg::Marker::CUBE;
       marker.id = j;
-      marker.header.frame_id = "camera";
+      marker.header.frame_id = params_.frame_id;
       marker.header.stamp = frame_stamp;
       marker.text = MarkerName;
       marker.pose.position.x = position[0] / 1000;

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -29,20 +29,11 @@ MicronTrackerDriver::MicronTrackerDriver(const rclcpp::NodeOptions & options)
   left_image_pub_ = create_publisher<sensor_msgs::msg::Image>("left_image", 10);
   right_image_pub_ = create_publisher<sensor_msgs::msg::Image>("right_image", 10);
 
-  // Use a timer to schedule periodic message publishing.
-  // timer_ = create_wall_timer(1s, [this]() {return this->on_timer();});
-
   // Initialize MTC library and connect to cameras
   init_mtc();
 
   // while node is running, process frames
-  bool ready;
   while (rclcpp::ok()) {
-    mtc::Markers_IsBackgroundFrameProcessedGet(&ready);
-    // Sleep for 1ms if not ready
-    // if (!ready) {
-    // std::this_thread::sleep_for(10ms);
-    // }
     process_frames();
   }
 }
@@ -101,12 +92,6 @@ void MicronTrackerDriver::init_mtc()
 
   IdentifiedMarkers = mtc::Collection_New();
   PoseXf = mtc::Xform3D_New();
-}
-
-void MicronTrackerDriver::on_timer()
-{
-  // Process frames and obtain measurements
-  process_frames();
 }
 
 void MicronTrackerDriver::process_frames()

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -52,7 +52,7 @@ MicronTrackerDriver::~MicronTrackerDriver()
 void MicronTrackerDriver::init_mtc()
 {
   // Initialize MTC library and connect to cameras
-  std::optional<std::string> calibrationDir = getMTHome();
+  std::optional<std::string> calibrationDir = mtr::getMTHome();
   if (!calibrationDir) {
     RCLCPP_ERROR(this->get_logger(), "MTHome environment variable not set");
     return;
@@ -201,14 +201,6 @@ void MicronTrackerDriver::process_frames()
   // Put the message into a queue to be processed by the middleware.
   // This call is non-blocking.
   marker_array_pub_->publish(std::move(msg));
-}
-
-std::optional<std::string> getMTHome()
-{
-  if (const char * localNamePtr = getenv("MTHome")) {
-    return std::string(localNamePtr);
-  }
-  return std::nullopt;
 }
 
 }  // namespace microntracker_components

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -90,7 +90,7 @@ void MicronTrackerDriver::init_mtc()
   RCLCPP_INFO(this->get_logger(), "The camera resolution is %d x %d", x, y);
 
 
-  IsBackGroundProcessingEnabled = true;
+  IsBackGroundProcessingEnabled = false;
   if (IsBackGroundProcessingEnabled) {
     MTC(mtc::Markers_BackGroundProcessSet(true));
     RCLCPP_INFO(this->get_logger(), "Background processing enabled");

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -80,10 +80,9 @@ void MicronTrackerDriver::init_mtc()
   auto t1 = now();
   mt_epoch = t0 + (t1 - t0) * 0.5;
 
-  int x, y;
-  MTR(mtc::Camera_ResolutionGet(CurrCamera, &x, &y));
-  RCLCPP_INFO(this->get_logger(), "The camera resolution is %d x %d", x, y);
-
+  int width, height;
+  MTR(mtc::Camera_ResolutionGet(CurrCamera, &width, &height));
+  RCLCPP_INFO(this->get_logger(), "The camera resolution is %d x %d", width, height);
 
   IsBackGroundProcessingEnabled = false;
   if (IsBackGroundProcessingEnabled) {

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -116,26 +116,29 @@ void MicronTrackerDriver::process_frames()
       return this->mt_epoch + duration;
     }();
 
-  int x, y;
-  MTR(mtc::Camera_ResolutionGet(CurrCamera, &x, &y));
-  x /= 4;
-  y /= 4;
-  int QuarterSizeImageBufferSize = (x * y) * 3;
+  int width, height, step;
+  MTR(mtc::Camera_ResolutionGet(CurrCamera, &width, &height));
+  width /= 4;
+  height /= 4;
+  step = width * 3;
+  bool is_bigendian = false;
+  int QuarterSizeImageBufferSize = (width * height) * 3;
 
   std::vector<unsigned char> leftImageBuffer(QuarterSizeImageBufferSize);
   std::vector<unsigned char> rightImageBuffer(QuarterSizeImageBufferSize);
+  std::string encoding = "rgb8";
   mtc::Camera_24BitQuarterSizeImagesGet(CurrCamera, leftImageBuffer.data(),
-      rightImageBuffer.data());
+                                            rightImageBuffer.data());
 
   // Publish left image
   auto left_image_msg = std::make_unique<sensor_msgs::msg::Image>();
   left_image_msg->header.frame_id = params_.frame_id;
   left_image_msg->header.stamp = frame_stamp;
-  left_image_msg->height = y;
-  left_image_msg->width = x;
-  left_image_msg->encoding = "rgb8";
-  left_image_msg->is_bigendian = false;
-  left_image_msg->step = 3 * x;
+  left_image_msg->height = height;
+  left_image_msg->width = width;
+  left_image_msg->encoding = encoding;
+  left_image_msg->is_bigendian = is_bigendian;
+  left_image_msg->step = step;
   left_image_msg->data = std::move(leftImageBuffer);
   left_image_pub_->publish(std::move(left_image_msg));
 
@@ -143,11 +146,11 @@ void MicronTrackerDriver::process_frames()
   auto right_image_msg = std::make_unique<sensor_msgs::msg::Image>();
   right_image_msg->header.frame_id = params_.frame_id;
   right_image_msg->header.stamp = frame_stamp;
-  right_image_msg->height = y;
-  right_image_msg->width = x;
-  right_image_msg->encoding = "rgb8";
-  right_image_msg->is_bigendian = false;
-  right_image_msg->step = 3 * x;
+  right_image_msg->height = height;
+  right_image_msg->width = width;
+  right_image_msg->encoding = encoding;
+  right_image_msg->is_bigendian = is_bigendian;
+  right_image_msg->step = step;
   right_image_msg->data = std::move(rightImageBuffer);
   right_image_pub_->publish(std::move(right_image_msg));
 

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -155,6 +155,8 @@ void MicronTrackerDriver::process_frames()
   auto clock = this->get_clock();
   RCLCPP_INFO_THROTTLE(this->get_logger(), *clock, 1000, "identified %d marker(s)",
                        mtc::Collection_Count(IdentifiedMarkers));
+  std::vector<double> position(3);
+  std::vector<double> orientation(4);
 
   for (int j = 1; j <= mtc::Collection_Count(IdentifiedMarkers); j++) {
     mtc::mtHandle Marker = mtc::Collection_Int(IdentifiedMarkers, j);
@@ -162,12 +164,11 @@ void MicronTrackerDriver::process_frames()
 
     if (IdentifyingCamera != 0) {
       char MarkerName[MT_MAX_STRING_LENGTH];
-      double Position[3], Quaternion[4];
       // mtc::mtMeasurementHazardCode Hazard;
 
       MTR(mtc::Marker_NameGet(Marker, MarkerName, MT_MAX_STRING_LENGTH, 0));
-      MTR(mtc::Xform3D_ShiftGet(PoseXf, Position));
-      MTR(mtc::Xform3D_RotQuaternionsGet(PoseXf, &Quaternion[0]));
+      MTR(mtc::Xform3D_ShiftGet(PoseXf, position.data()));
+      MTR(mtc::Xform3D_RotQuaternionsGet(PoseXf, orientation.data()));
       // MTR(mtc::Xform3D_HazardCodeGet(PoseXf, &Hazard));
 
       visualization_msgs::msg::Marker marker;
@@ -176,13 +177,13 @@ void MicronTrackerDriver::process_frames()
       marker.header.frame_id = "camera";
       marker.header.stamp = frame_stamp;
       marker.text = MarkerName;
-      marker.pose.position.x = Position[0] / 1000;
-      marker.pose.position.y = Position[1] / 1000;
-      marker.pose.position.z = Position[2] / 1000;
-      marker.pose.orientation.x = Quaternion[0];
-      marker.pose.orientation.y = Quaternion[1];
-      marker.pose.orientation.z = Quaternion[2];
-      marker.pose.orientation.w = Quaternion[3];
+      marker.pose.position.x = position[0] / 1000;
+      marker.pose.position.y = position[1] / 1000;
+      marker.pose.position.z = position[2] / 1000;
+      marker.pose.orientation.x = orientation[0];
+      marker.pose.orientation.y = orientation[1];
+      marker.pose.orientation.z = orientation[2];
+      marker.pose.orientation.w = orientation[3];
       marker.scale.x = 0.05;
       marker.scale.y = 0.05;
       marker.scale.z = 0.05;

--- a/microntracker_components/src/microntracker_component.cpp
+++ b/microntracker_components/src/microntracker_component.cpp
@@ -162,12 +162,12 @@ void MicronTrackerDriver::process_frames()
 
     if (IdentifyingCamera != 0) {
       char MarkerName[MT_MAX_STRING_LENGTH];
-      double Position[3], Angle[3];
+      double Position[3], Quaternion[4];
       // mtc::mtMeasurementHazardCode Hazard;
 
       MTR(mtc::Marker_NameGet(Marker, MarkerName, MT_MAX_STRING_LENGTH, 0));
       MTR(mtc::Xform3D_ShiftGet(PoseXf, Position));
-      MTR(mtc::Xform3D_RotAnglesDegsGet(PoseXf, &Angle[0], &Angle[1], &Angle[2]));
+      MTR(mtc::Xform3D_RotQuaternionsGet(PoseXf, &Quaternion[0]));
       // MTR(mtc::Xform3D_HazardCodeGet(PoseXf, &Hazard));
 
       visualization_msgs::msg::Marker marker;
@@ -179,10 +179,10 @@ void MicronTrackerDriver::process_frames()
       marker.pose.position.x = Position[0] / 1000;
       marker.pose.position.y = Position[1] / 1000;
       marker.pose.position.z = Position[2] / 1000;
-      marker.pose.orientation.x = Angle[0];
-      marker.pose.orientation.y = Angle[1];
-      marker.pose.orientation.z = Angle[2];
-      marker.pose.orientation.w = 1.0;
+      marker.pose.orientation.x = Quaternion[0];
+      marker.pose.orientation.y = Quaternion[1];
+      marker.pose.orientation.z = Quaternion[2];
+      marker.pose.orientation.w = Quaternion[3];
       marker.scale.x = 0.05;
       marker.scale.y = 0.05;
       marker.scale.z = 0.05;

--- a/microntracker_components/src/microntracker_components_parameters.yaml
+++ b/microntracker_components/src/microntracker_components_parameters.yaml
@@ -26,3 +26,9 @@ microntracker_components:
         one_of<>: [ [ "Bpp12", "Bpp14" ] ]
           # - "Bpp12" # 12-bit pixel depth requested
           # - "Bpp14" # 14-bit pixel depth requested
+  frame_id:
+    type: string
+    default_value: "camera"
+    description: "Sets the frame_id for the camera"
+    validation:
+      not_empty<>: []

--- a/microntracker_components/src/microntracker_components_parameters.yaml
+++ b/microntracker_components/src/microntracker_components_parameters.yaml
@@ -1,0 +1,28 @@
+microntracker_components:
+  mt:
+    frame_type:
+      type: string
+      default_value: "Alternating"
+      description: "Sets mtFrameType for camera streaming mode"
+      validation:
+        one_of<>: [ [ "Alternating", "Full", "ROIs" ] ]
+          # - "Alternating" # Alternating frames of ROIs and image data are received (combined for convenience)
+          # - "Full" # Frames received at full resolution and bit-depth
+          # - "ROIs" # Only XPoint regions of interest are received
+    decimation:
+      type: string
+      default_value: "Dec41"
+      description: "Sets mtDecimation for camera streaming mode"
+      validation:
+        one_of<>: [ [ "Dec11", "Dec21", "Dec41" ] ]
+          # - "Dec11" # Images received with no decimation (1:1)
+          # - "Dec21" # Images received with 2:1 decimation, i.e. every 2nd row and column is kept
+          # - "Dec41" # Images received with 4:1 decimation, i.e. every 4th row and column is kept
+    bit_depth:
+      type: string
+      default_value: "Bpp12"
+      description: "Sets mtBitDepth for camera streaming mode"
+      validation:
+        one_of<>: [ [ "Bpp12", "Bpp14" ] ]
+          # - "Bpp12" # 12-bit pixel depth requested
+          # - "Bpp14" # 14-bit pixel depth requested

--- a/microntracker_components/src/microntracker_components_parameters.yaml
+++ b/microntracker_components/src/microntracker_components_parameters.yaml
@@ -1,14 +1,19 @@
 microntracker_components:
+  frame_id:
+    type: string
+    default_value: "camera"
+    description: "Sets the frame_id for the camera"
+    validation:
+      not_empty<>: []
   mt:
-    frame_type:
+    bit_depth:
       type: string
-      default_value: "Alternating"
-      description: "Sets mtFrameType for camera streaming mode"
+      default_value: "Bpp12"
+      description: "Sets mtBitDepth for camera streaming mode"
       validation:
-        one_of<>: [ [ "Alternating", "Full", "ROIs" ] ]
-          # - "Alternating" # Alternating frames of ROIs and image data are received (combined for convenience)
-          # - "Full" # Frames received at full resolution and bit-depth
-          # - "ROIs" # Only XPoint regions of interest are received
+        one_of<>: [ [ "Bpp12", "Bpp14" ] ]
+          # - "Bpp12" # 12-bit pixel depth requested
+          # - "Bpp14" # 14-bit pixel depth requested
     decimation:
       type: string
       default_value: "Dec41"
@@ -18,17 +23,12 @@ microntracker_components:
           # - "Dec11" # Images received with no decimation (1:1)
           # - "Dec21" # Images received with 2:1 decimation, i.e. every 2nd row and column is kept
           # - "Dec41" # Images received with 4:1 decimation, i.e. every 4th row and column is kept
-    bit_depth:
+    frame_type:
       type: string
-      default_value: "Bpp12"
-      description: "Sets mtBitDepth for camera streaming mode"
+      default_value: "Alternating"
+      description: "Sets mtFrameType for camera streaming mode"
       validation:
-        one_of<>: [ [ "Bpp12", "Bpp14" ] ]
-          # - "Bpp12" # 12-bit pixel depth requested
-          # - "Bpp14" # 14-bit pixel depth requested
-  frame_id:
-    type: string
-    default_value: "camera"
-    description: "Sets the frame_id for the camera"
-    validation:
-      not_empty<>: []
+        one_of<>: [ [ "Alternating", "Full", "ROIs" ] ]
+          # - "Alternating" # Alternating frames of ROIs and image data are received (combined for convenience)
+          # - "Full" # Frames received at full resolution and bit-depth
+          # - "ROIs" # Only XPoint regions of interest are received


### PR DESCRIPTION
Includes a number of improvements including:

- Propagate hardware time stamps using measured epoch from initialization reset
- Disable background processing to use blocking calls for rate limiting and syncopation
- Use generate_parameter_library to add ros params for frame_id and MT camera modes
- Code re-origination and cleanup
- Get orientation via Quaternions to avoid euler angle singularities